### PR TITLE
fix: listview jitters when updating data

### DIFF
--- a/src/component/ListView.js
+++ b/src/component/ListView.js
@@ -1,21 +1,24 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Bar from './Bar';
 import PropTypes from 'prop-types';
 import { Grid, CircularProgress } from '@material-ui/core';
 
 const ListView = (props) => {
   const title = props.title;
-  const listData =
-    props.data && props.data.length > 0
-      ? props.data.sort((a, b) => {
-          if (a.max === 0) {
-            return 1;
-          } else if (b.max === 0) {
-            return -1;
-          }
-          return b.rest / b.max - a.rest / a.max;
-        })
-      : [];
+  const listData = useMemo(
+    () =>
+      props.data && props.data.length > 0
+        ? [...props.data].sort((a, b) => {
+            if (a.max === 0) {
+              return 1;
+            } else if (b.max === 0) {
+              return -1;
+            }
+            return b.rest / b.max - a.rest / a.max;
+          })
+        : [],
+    [props.data]
+  );
   const renderList = (list) =>
     list.map((ele) => (
       <Grid item key={ele.name}>


### PR DESCRIPTION
Currently, listviews may jitter when updating data if there's more than one item that doesn't have any valid data. If you watch the library list closely, you may find that '徐汇社科馆' and '包玉刚图书馆' swap every 10 seconds.
Applying sort to a list is an in-place operation, so the prop of a listview is modified every time it is rendered, which makes the operation non-idempotent. Unfortunately, the sort function is not stable and swaps invalid items back and forth, causing the jitter. Copying the array and sort it instead can solve this issue.